### PR TITLE
Set correct scale factor

### DIFF
--- a/src/gui/gui_thread.rs
+++ b/src/gui/gui_thread.rs
@@ -408,13 +408,15 @@ impl GUIThread {
                 .unwrap()
         };
 
-        #[cfg(debug_assertions)]
-        println!("scale factor = {}", window.window().scale_factor());
-
         let glow_context =
             unsafe { glow::Context::from_loader_function(|s| window.get_proc_address(s)) };
         let glow_context = Rc::new(glow_context);
         let egui_glow = EguiGlow::new(window.window(), glow_context.clone());
+
+        let scale_factor = window.window().scale_factor();
+        #[cfg(debug_assertions)]
+        println!("scale factor = {}", scale_factor);
+        egui_glow.egui_ctx.set_pixels_per_point(1.0);
 
         let thread = GUIThread {
             ui: UI::new(


### PR DESCRIPTION
This PR tries to fix https://github.com/t-sin/soyboy-sp.vst3/issues/2 .

Tested on:

- Lenovo ThinkPad X1 Carbon 6th Gen (scale factor = 1.66666666)
- Acer EB321HQU (scale factor = 1.0)

If calculated scale factor it not 1.0 in the environment (depends on dots per inch value?), the value `egui::Context::pixels_per_point` is automatically changed but it may be wrong.
So it is neccessary to reset manually this value to `1.0` by [`egui::Context::set_pixels_per_point()`](https://docs.rs/egui/latest/egui/struct.Context.html#method.set_pixels_per_point) .

This PR fixes the issue https://github.com/t-sin/soyboy-sp.vst3/issues/2 but high DPI problems may occur in the future.
